### PR TITLE
Fix empty error messages with meaningful fallbacks

### DIFF
--- a/scripts/test_empty_error.py
+++ b/scripts/test_empty_error.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Test script to reproduce and handle empty error messages
+"""
+
+import asyncio
+import json
+import sys
+import os
+
+# Add the src directory to Python path for local testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from definite_mcp import run_sql_query
+
+
+async def test_attio_query():
+    """Test the specific ATTIO query that returns empty error"""
+    print("Testing ATTIO query that might return empty error...")
+    print("-" * 50)
+
+    sql = """SELECT COUNT(*) AS company_count
+FROM ATTIO.companies"""
+
+    result = await run_sql_query(sql)
+
+    print(f"Query: {sql}")
+    print(f"\nResult:")
+    print(json.dumps(result, indent=2))
+
+    if "error" in result:
+        error_msg = result["error"]
+        if error_msg == "":
+            print("\n⚠️  Empty error message detected!")
+            print("This happens when the API returns a response with an empty 'message' field")
+            print(f"HTTP Status: {result.get('http_status', 'N/A')}")
+        else:
+            print(f"\n✓ Error message: {error_msg}")
+    else:
+        print("\n✓ Query succeeded")
+
+    return result
+
+
+async def simulate_empty_error():
+    """Simulate what happens when API returns empty message"""
+    print("\nSimulating API response with empty message...")
+    print("-" * 50)
+
+    import definite_mcp
+    import httpx
+
+    original_make_api_request = definite_mcp.make_api_request
+
+    async def mock_empty_error_response(endpoint: str, payload: dict):
+        # Simulate an HTTP error with empty message
+        response = httpx.Response(
+            status_code=400,
+            json={"message": ""},  # Empty message
+            request=httpx.Request("POST", "http://test.com")
+        )
+        raise httpx.HTTPStatusError(
+            "Bad Request",
+            request=response.request,
+            response=response
+        )
+
+    definite_mcp.make_api_request = mock_empty_error_response
+
+    try:
+        sql = "SELECT 1"
+        result = await run_sql_query(sql)
+
+        print("Result with empty error message:")
+        print(json.dumps(result, indent=2))
+
+        if result.get("error") == "":
+            print("\n✓ Confirmed: Empty error message is returned as-is")
+            print("This matches the behavior you're seeing")
+
+    finally:
+        definite_mcp.make_api_request = original_make_api_request
+
+
+async def main():
+    """Run tests for empty error scenarios"""
+    print("=" * 60)
+    print("EMPTY ERROR MESSAGE TEST")
+    print("=" * 60)
+    print()
+
+    # Test the actual ATTIO query
+    await test_attio_query()
+
+    # Simulate the empty error scenario
+    await simulate_empty_error()
+
+    print("\n" + "=" * 60)
+    print("ANALYSIS")
+    print("=" * 60)
+    print("\nThe empty error occurs when:")
+    print("1. The Definite API returns an HTTP error status (400, 500, etc.)")
+    print("2. The response JSON contains: {\"message\": \"\"}")
+    print("3. The MCP extracts this empty message and returns it as-is")
+    print("\nThis could happen when:")
+    print("• The database/schema doesn't exist (ATTIO schema not found)")
+    print("• Permission issues with empty error details")
+    print("• API validation errors without descriptive messages")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_empty_error_fix.py
+++ b/scripts/test_empty_error_fix.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Test that empty error messages are now replaced with fallback messages
+"""
+
+import asyncio
+import json
+import sys
+import os
+
+# Add the src directory to Python path for local testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from definite_mcp import run_sql_query, run_cube_query
+
+
+async def test_empty_sql_error():
+    """Test SQL query with simulated empty error"""
+    print("Testing SQL query with empty error message...")
+    print("-" * 50)
+
+    import definite_mcp
+    import httpx
+
+    original_make_api_request = definite_mcp.make_api_request
+
+    async def mock_empty_error(endpoint: str, payload: dict):
+        response = httpx.Response(
+            status_code=400,
+            json={"message": ""},  # Empty message
+            request=httpx.Request("POST", "http://test.com")
+        )
+        raise httpx.HTTPStatusError("Bad Request", request=response.request, response=response)
+
+    definite_mcp.make_api_request = mock_empty_error
+
+    try:
+        sql = "SELECT * FROM test_table"
+        result = await run_sql_query(sql)
+
+        print(f"Query: {sql}")
+        print(f"\nResult:")
+        print(json.dumps(result, indent=2))
+
+        if result.get("error"):
+            if result["error"] == "":
+                print("\n❌ Still returning empty error!")
+            else:
+                print(f"\n✅ Fixed! Now returns: '{result['error']}'")
+                print("   Instead of an empty string")
+
+    finally:
+        definite_mcp.make_api_request = original_make_api_request
+
+    print()
+
+
+async def test_empty_cube_error():
+    """Test Cube query with simulated empty error"""
+    print("Testing Cube query with empty error message...")
+    print("-" * 50)
+
+    import definite_mcp
+    import httpx
+
+    original_make_api_request = definite_mcp.make_api_request
+
+    async def mock_empty_error(endpoint: str, payload: dict):
+        response = httpx.Response(
+            status_code=500,
+            json={"message": ""},  # Empty message
+            request=httpx.Request("POST", "http://test.com")
+        )
+        raise httpx.HTTPStatusError("Server Error", request=response.request, response=response)
+
+    definite_mcp.make_api_request = mock_empty_error
+
+    try:
+        cube_query = {
+            "dimensions": [],
+            "measures": ["test.metric"],
+            "filters": []
+        }
+        result = await run_cube_query(cube_query)
+
+        print(f"Cube Query: {json.dumps(cube_query)}")
+        print(f"\nResult:")
+        print(json.dumps(result, indent=2))
+
+        if result.get("error"):
+            if result["error"] == "":
+                print("\n❌ Still returning empty error!")
+            else:
+                print(f"\n✅ Fixed! Now returns: '{result['error']}'")
+                print("   Instead of an empty string")
+
+    finally:
+        definite_mcp.make_api_request = original_make_api_request
+
+    print()
+
+
+async def test_empty_after_extraction():
+    """Test when 'Something went wrong:' is followed by empty string"""
+    print("Testing 'Something went wrong:' with empty content...")
+    print("-" * 50)
+
+    import definite_mcp
+    import httpx
+
+    original_make_api_request = definite_mcp.make_api_request
+
+    async def mock_empty_after_extraction(endpoint: str, payload: dict):
+        response = httpx.Response(
+            status_code=400,
+            json={"message": "HTTP error 500: Something went wrong: "},  # Empty after colon
+            request=httpx.Request("POST", "http://test.com")
+        )
+        raise httpx.HTTPStatusError("Bad Request", request=response.request, response=response)
+
+    definite_mcp.make_api_request = mock_empty_after_extraction
+
+    try:
+        sql = "SELECT 1"
+        result = await run_sql_query(sql)
+
+        print(f"Query: {sql}")
+        print(f"\nResult:")
+        print(json.dumps(result, indent=2))
+
+        if result.get("error"):
+            if result["error"] == "":
+                print("\n❌ Still returning empty error after extraction!")
+            else:
+                print(f"\n✅ Fixed! Now returns: '{result['error']}'")
+                print("   Instead of an empty string after extraction")
+
+    finally:
+        definite_mcp.make_api_request = original_make_api_request
+
+
+async def main():
+    """Test all empty error scenarios are fixed"""
+    print("=" * 60)
+    print("EMPTY ERROR FIX VERIFICATION")
+    print("=" * 60)
+    print()
+
+    await test_empty_sql_error()
+    await test_empty_cube_error()
+    await test_empty_after_extraction()
+
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print("\n✅ Empty error messages are now replaced with:")
+    print("   'Query failed with HTTP {status_code}'")
+    print("\nThis provides more useful information than an empty string,")
+    print("letting users know the query failed and the HTTP status.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/definite_mcp/__init__.py
+++ b/src/definite_mcp/__init__.py
@@ -96,14 +96,16 @@ async def run_sql_query(sql: str, integration_id: Optional[str] = None) -> Dict[
                     # Extract just the SQL error part
                     sql_error = msg.split("Something went wrong:", 1)[1].strip()
                     return {
-                        "error": sql_error,
+                        "error": sql_error if sql_error else f"Query failed with HTTP {e.response.status_code}",
                         "status": "failed",
                         "http_status": e.response.status_code,
                         "query": sql
                     }
                 else:
+                    # If message is empty, provide a fallback error message
+                    error_msg = msg if msg else f"Query failed with HTTP {e.response.status_code}"
                     return {
-                        "error": msg,
+                        "error": error_msg,
                         "status": "failed",
                         "http_status": e.response.status_code,
                         "query": sql
@@ -171,14 +173,16 @@ async def run_cube_query(
                     # Extract just the error part
                     cube_error = msg.split("Something went wrong:", 1)[1].strip()
                     return {
-                        "error": cube_error,
+                        "error": cube_error if cube_error else f"Query failed with HTTP {e.response.status_code}",
                         "status": "failed",
                         "http_status": e.response.status_code,
                         "cube_query": cube_query
                     }
                 else:
+                    # If message is empty, provide a fallback error message
+                    error_msg = msg if msg else f"Query failed with HTTP {e.response.status_code}"
                     return {
-                        "error": msg,
+                        "error": error_msg,
                         "status": "failed",
                         "http_status": e.response.status_code,
                         "cube_query": cube_query


### PR DESCRIPTION
When the Definite API returns an empty error message, provide a fallback message instead of returning an empty string.

Changes:
- Check if error message is empty and provide fallback "Query failed with HTTP {status}"
- Handle empty messages after extracting "Something went wrong:" prefix
- Add comprehensive tests for empty error scenarios

This ensures users always get meaningful error information even when the upstream API returns empty error messages.

🤖 Generated with [Claude Code](https://claude.ai/code)