### PR TITLE
Add request details and exception type to error responses

### DIFF
--- a/src/definite_mcp/__init__.py
+++ b/src/definite_mcp/__init__.py
@@ -99,7 +99,13 @@ async def run_sql_query(sql: str, integration_id: Optional[str] = None) -> Dict[
                         "error": sql_error if sql_error else f"Query failed with HTTP {e.response.status_code}",
                         "status": "failed",
                         "http_status": e.response.status_code,
-                        "query": sql
+                        "query": sql,
+                        "request_details": {
+                            "url": f"{API_BASE_URL}/v1/query",
+                            "payload": payload,
+                            "api_key_configured": bool(API_KEY),
+                            "timeout": "120 seconds"
+                        }
                     }
                 else:
                     # If message is empty, provide a fallback error message
@@ -108,7 +114,13 @@ async def run_sql_query(sql: str, integration_id: Optional[str] = None) -> Dict[
                         "error": error_msg,
                         "status": "failed",
                         "http_status": e.response.status_code,
-                        "query": sql
+                        "query": sql,
+                        "request_details": {
+                            "url": f"{API_BASE_URL}/v1/query",
+                            "payload": payload,
+                            "api_key_configured": bool(API_KEY),
+                            "timeout": "120 seconds"
+                        }
                     }
         except (json.JSONDecodeError, KeyError):
             pass
@@ -116,15 +128,44 @@ async def run_sql_query(sql: str, integration_id: Optional[str] = None) -> Dict[
         return {
             "error": f"HTTP {e.response.status_code}: {error_detail}",
             "status": "failed",
-            "query": sql
+            "query": sql,
+            "request_details": {
+                "url": f"{API_BASE_URL}/v1/query",
+                "payload": payload,
+                "api_key_configured": bool(API_KEY),
+                "timeout": "120 seconds"
+            }
         }
     except Exception as e:
         error_msg = str(e)
-        return {
-            "error": error_msg if error_msg else "Query failed with unknown error",
+
+        # If empty message, provide more specific error based on exception type
+        if not error_msg:
+            if e.__class__.__module__ == 'httpx':
+                # Include the exception class name for httpx errors
+                error_msg = f"Query failed with {e.__class__.__name__}"
+            else:
+                error_msg = f"Query failed with {e.__class__.__name__}: unknown error"
+
+        # Build error response with additional context
+        error_response = {
+            "error": error_msg,
             "status": "failed",
             "query": sql
         }
+
+        # Add exception type for debugging
+        error_response["exception_type"] = f"{e.__class__.__module__}.{e.__class__.__name__}"
+
+        # Add request details for debugging
+        error_response["request_details"] = {
+            "url": f"{API_BASE_URL}/v1/query",
+            "payload": payload,
+            "api_key_configured": bool(API_KEY),
+            "timeout": "120 seconds"
+        }
+
+        return error_response
 
 
 @mcp.tool()
@@ -177,7 +218,13 @@ async def run_cube_query(
                         "error": cube_error if cube_error else f"Query failed with HTTP {e.response.status_code}",
                         "status": "failed",
                         "http_status": e.response.status_code,
-                        "cube_query": cube_query
+                        "cube_query": cube_query,
+                        "request_details": {
+                            "url": f"{API_BASE_URL}/v1/query",
+                            "payload": payload,
+                            "api_key_configured": bool(API_KEY),
+                            "timeout": "120 seconds"
+                        }
                     }
                 else:
                     # If message is empty, provide a fallback error message
@@ -186,7 +233,13 @@ async def run_cube_query(
                         "error": error_msg,
                         "status": "failed",
                         "http_status": e.response.status_code,
-                        "cube_query": cube_query
+                        "cube_query": cube_query,
+                        "request_details": {
+                            "url": f"{API_BASE_URL}/v1/query",
+                            "payload": payload,
+                            "api_key_configured": bool(API_KEY),
+                            "timeout": "120 seconds"
+                        }
                     }
         except (json.JSONDecodeError, KeyError):
             pass
@@ -194,15 +247,44 @@ async def run_cube_query(
         return {
             "error": f"HTTP {e.response.status_code}: {error_detail}",
             "status": "failed",
-            "cube_query": cube_query
+            "cube_query": cube_query,
+            "request_details": {
+                "url": f"{API_BASE_URL}/v1/query",
+                "payload": payload,
+                "api_key_configured": bool(API_KEY),
+                "timeout": "120 seconds"
+            }
         }
     except Exception as e:
         error_msg = str(e)
-        return {
-            "error": error_msg if error_msg else "Query failed with unknown error",
+
+        # If empty message, provide more specific error based on exception type
+        if not error_msg:
+            if e.__class__.__module__ == 'httpx':
+                # Include the exception class name for httpx errors
+                error_msg = f"Query failed with {e.__class__.__name__}"
+            else:
+                error_msg = f"Query failed with {e.__class__.__name__}: unknown error"
+
+        # Build error response with additional context
+        error_response = {
+            "error": error_msg,
             "status": "failed",
             "cube_query": cube_query
         }
+
+        # Add exception type for debugging
+        error_response["exception_type"] = f"{e.__class__.__module__}.{e.__class__.__name__}"
+
+        # Add request details for debugging
+        error_response["request_details"] = {
+            "url": f"{API_BASE_URL}/v1/query",
+            "payload": payload,
+            "api_key_configured": bool(API_KEY),
+            "timeout": "120 seconds"
+        }
+
+        return error_response
 
 
 def main():


### PR DESCRIPTION
Enhance error responses with comprehensive debugging information to help users understand and diagnose query failures.

Changes:
- Add exception_type field showing full module.ClassName for non-HTTP errors
- Add request_details field to all error responses containing:
  - URL: The exact API endpoint called
  - Payload: Full request including SQL/Cube query and integration_id
  - API key configuration status
  - Timeout setting (120 seconds)
- Improve error messages for exceptions with empty string representations by including the exception class name (e.g., "Query failed with TimeoutException")

This helps users debug:
- Network issues (ConnectError, TimeoutException, NetworkError)
- Which specific query and parameters failed
- Whether the API key was properly configured
- The exact request that was attempted

🤖 Generated with [Claude Code](https://claude.ai/code)